### PR TITLE
Make the repeating interval for the sched a number

### DIFF
--- a/lib/angular-scheduler.js
+++ b/lib/angular-scheduler.js
@@ -216,7 +216,7 @@ angular.module('AngularScheduler', ['underscore'])
                     var options = {};
                     options.startDate = this.scope.schedulerUTCTime;
                     options.frequency = this.scope.schedulerFrequency.value;
-                    options.interval = this.scope.schedulerInterval;
+                    options.interval = parseInt(this.scope.schedulerInterval);
                     if (this.scope.schedulerEnd.value === 'after') {
                         options.occurrenceCount = this.scope.schedulerOccurrenceCount;
                     }


### PR DESCRIPTION
There was an issue where if you typed into the schedule interval form option, it would be put on scope as a string (and would mess up the occurrences list).

For example, typing "15" minutes for the repeating interval would result in occurrences at 10:00, 10:15, 11:15, 12:15, etc.

Note that this bug is only reproducible with typing in the number, if you use the arrows next to the input, it will automatically be put on scope as a number.

PS: you did a great job on form-generator, and I enjoy using it :).